### PR TITLE
Fix state tracking bug in execute_notebook_code decorator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-jupyter"
-version = "2.0.0"
+version = "2.0.1"
 description = "MCP Jupyter"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_jupyter/server.py
+++ b/src/mcp_jupyter/server.py
@@ -981,7 +981,7 @@ def _modify_delete_cell(notebook_path: str, position_index: int) -> dict:
 
 
 @mcp.tool()
-@NotebookState.refreshes_state
+@NotebookState.state_dependent
 def execute_notebook_code(
     notebook_path: str,
     execution_type: str,


### PR DESCRIPTION
 ## Fix State Tracking Bug in Code Execution

  ### Summary
  Fixed a decorator bug where `execute_notebook_code` wasn't detecting
  manual notebook changes before execution, causing operations to proceed
  with stale state.

  ### Changes
  - **Fixed decorator**: Changed `execute_notebook_code` from
  `@refreshes_state` to `@state_dependent`
  - **Improved reliability**: Now detects manual changes (like user
  installing packages) before MCP operations

  ### Bug Details
  The issue occurred when:
  1. User manually adds/modifies cells (e.g., installs xgboost in cell
  [8])
  2. MCP `execute_notebook_code` called (e.g., install_packages operation)
  3. Operation proceeded without detecting notebook changes
  4. Could lead to duplicate installations or wrong cell execution

These don't impact the more usual modify_notebook_cells and won't make additional overhead since those call the internal _execute_cell_internal() to avoid checking the hash during the operation.

  Affects both `execute_cell` and `install_packages` execution types.