### PR TITLE
Enable automatic WebSocket reconnection for kernel client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-jupyter"
-version = "2.0.1"
+version = "2.0.2"
 description = "MCP Jupyter"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_jupyter/server.py
+++ b/src/mcp_jupyter/server.py
@@ -182,6 +182,9 @@ def get_kernel(notebook_path: str, server_url: str = None) -> Optional[KernelCli
             server_url=server_url,
             token=TOKEN,
             kernel_id=get_kernel_id(notebook_path, server_url),
+            client_kwargs={
+                "reconnect_interval": 5
+            },  # Auto-reconnect if WebSocket closes
         )
 
         new_kernel.start()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,8 @@ from pathlib import Path
 
 import pytest
 
+import mcp_jupyter.server
+
 # Fixtures for MCP Jupyter integration tests
 
 # Constants
@@ -210,6 +212,14 @@ def jupyter_server():
     )
 
     yield server_url
+
+    # Clean up any lingering kernel connections
+    try:
+        if mcp_jupyter.server.kernel is not None:
+            print("Cleaning up kernel connection...")
+            mcp_jupyter.server.kernel.stop()
+    except Exception as e:
+        print(f"Error cleaning up kernel: {e}")
 
     _cleanup_jupyter_server(server_process, test_notebooks_dir, "session ")
 

--- a/tests/test_check_server.py
+++ b/tests/test_check_server.py
@@ -3,7 +3,7 @@
 import pytest
 
 from mcp_jupyter.rest_client import NotebookClient
-from mcp_jupyter.server import query_notebook
+from mcp_jupyter.server import get_kernel, query_notebook
 
 
 def test_check_server_without_notebook(jupyter_server):
@@ -56,3 +56,20 @@ def test_get_default_kernel_info(jupyter_server):
     assert kernelspec["language"] == "python"
     assert language_info["name"] == "python"
     assert "python" in kernelspec["display_name"].lower()
+
+
+def test_reconnect_interval_configured(jupyter_server, test_notebook):
+    """Test that kernel client is initialized with reconnect_interval."""
+    # Get the kernel
+    kernel = get_kernel(test_notebook)
+    assert kernel is not None
+
+    # Check that the underlying WebSocket client has reconnect_interval set
+    # The client is accessed via kernel._manager.client
+    ws_client = kernel._manager.client
+
+    # Verify reconnect_interval is set to 5 (not the default 0)
+    assert hasattr(ws_client, "reconnect_interval")
+    assert ws_client.reconnect_interval == 5, (
+        f"Expected reconnect_interval=5, got {ws_client.reconnect_interval}"
+    )


### PR DESCRIPTION
When users are idle for awhile the connection can close. This will reconnect.

The reconnect_interval parameter makes the WebSocket client continuously
 monitor the connection and auto-reconnect if it drops, as long as:
- The kernel process is alive
- The Jupyter server is running
- The kernel ID is still valid